### PR TITLE
Updated act_command to match new protocol

### DIFF
--- a/src/Utils/Hexagons.svelte
+++ b/src/Utils/Hexagons.svelte
@@ -20,7 +20,6 @@ let pendingTimeout;
 let resendCommand;
 let isTouch = false;
 let boundRect;
-let numTouches = 1;
 let endpoint;
 let nopRoute;
 let success;

--- a/src/Utils/Hexagons.svelte
+++ b/src/Utils/Hexagons.svelte
@@ -196,7 +196,7 @@ $: drawableHexagons = hexagonsLayout.map(({id, row, col}) => {
     return {id, x, y, width, height, points: points.join(' '), color};
 });
 
-function sendCommandBlocks() {
+export function sendCommandBlocks() {
     (async () => {
         return await Com.hitEndpoint(endpoint, nopRoute, $act_command);
     })().then(result => {

--- a/src/Utils/Hexagons.svelte
+++ b/src/Utils/Hexagons.svelte
@@ -1,5 +1,5 @@
 <script>
-import { block0_31, block32_63, block64_95, block96_127, act_command, message, OP_Mode, preset_display } from "../../stores/stores.js";
+import { block0_31, block32_63, block64_95, block96_127, act_command, message, command, preset_display } from "../../stores/stores.js";
 import Communication from "./Communication.svelte";
 import Moveable from "svelte-moveable";
 import { onMount } from "svelte";
@@ -243,14 +243,10 @@ function findActiveHexagons(e) {
 }
 
 export async function AllOff() {
-    let temp_OP = $OP_Mode;
-    $OP_Mode = 0;
-    $block0_31 = [0,0,0,0];
-    $block32_63 = [0,0,0,0];
-    $block64_95 = [0,0,0,0];
-    $block96_127 = [0,0,0,0];
+    let temp_OP = $command;
+    $command = 0;
     sendCommandBlocks();
-    $OP_Mode = temp_OP;
+    $command = temp_OP;
 }
 
 function handleTouchStart(e) { 
@@ -278,7 +274,7 @@ function handleTouchStart(e) {
 
     if(!isPreset && arraySize != "small") {
         findActiveHexagons(e);
-        resendCommand = setInterval(() => {if($OP_Mode == 0x05){hexCache = [];} findActiveHexagons(e);}, 50);
+        resendCommand = setInterval(() => {if($command == 0x05){hexCache = [];} findActiveHexagons(e);}, 50);
     }
 }
 
@@ -300,7 +296,7 @@ function handleTouchMove(e) {
         if (pendingTimeout) { 
             clearTimeout(pendingTimeout);
         }
-        pendingTimeout = setTimeout(() => {resendCommand = setInterval(() => {if($OP_Mode == 0x05){hexCache = [];} findActiveHexagons(e);}, 50)}, 50);
+        pendingTimeout = setTimeout(() => {resendCommand = setInterval(() => {if($command == 0x05){hexCache = [];} findActiveHexagons(e);}, 50)}, 50);
     }
     if (isTouch) {
         Xend = e.targetTouches[0].clientX - boundRect.left;
@@ -314,7 +310,7 @@ function handleTouchMove(e) {
 function handleTouchEnd(e) {
     if(e.stopPropagation) e.stopPropagation();
     if(e.preventDefault) e.preventDefault();
-    if ($OP_Mode == 0x05) hexCache = [];
+    if ($command == 0x05) hexCache = [];
     try{
         tpCache = [...tpCache.filter(tp => tp.identifier != e.changedTouches[0].identifier)];
         if (tpCache.length == 0) throw "No more Touches";
@@ -329,47 +325,47 @@ function handleTouchEnd(e) {
     }
 
     if (isPreset) {
-        let temp = $OP_Mode;
+        let temp = $command;
         if (presetName == "sweep") {
             if (deltaX > 0 && Math.abs(deltaY) < 75 ){
                     console.log('LR');
-                    $OP_Mode = 0x86;
+                    $command = 0x86;
                     display_preset("sweep-LR");
             } else if (deltaX < 0 && Math.abs(deltaY) < 75) {
                     console.log('RL');
-                    $OP_Mode = 0x87;
+                    $command = 0x87;
                     display_preset("sweep-RL");
             } else if (deltaY > 0 && Math.abs(deltaX) < 75) {
                     console.log('TB');
-                    $OP_Mode = 0x88;
+                    $command = 0x88;
                     display_preset("sweep-TB");
             } else if (deltaY < 0 && Math.abs(deltaX) < 75) { 
                     console.log('BT');
-                    $OP_Mode = 0x89;
+                    $command = 0x89;
                     display_preset("sweep-BT");
             } else if (deltaX > 0 && deltaY < 0) {
                     console.log('+45BT');
-                    $OP_Mode = 0x8a;
+                    $command = 0x8a;
                     display_preset("sweep+45BT");
             } else if (deltaX < 0 && deltaY > 0) {
                     console.log('+45TB');
-                    $OP_Mode = 0x8b;
+                    $command = 0x8b;
                     display_preset("sweep+45TB");
             } else if (deltaX < 0 && deltaY < 0) {
                     console.log('-45BT');
-                    $OP_Mode = 0x8c;
+                    $command = 0x8c;
                     display_preset("sweep-45BT");
             } else if (deltaX > 0 && deltaY > 0) {
                     console.log('-45TB');
-                    $OP_Mode = 0x8d;
+                    $command = 0x8d;
                     display_preset("sweep-45TB");
             }
         } else if (presetName == "FlashAll") {
-            $OP_Mode = 0x80;
+            $command = 0x80;
             display_preset("flashall");
         }
         sendCommandBlocks();
-        $OP_Mode = temp;
+        $command = temp;
     }
 }
 

--- a/src/Utils/Hexagons.svelte
+++ b/src/Utils/Hexagons.svelte
@@ -236,7 +236,7 @@ function findActiveHexagons(e) {
             }
         }
     }
-    if (JSON.stringify(hexCache) != JSON.stringify(activeHexagon)) {
+    if (JSON.stringify(hexCache) != JSON.stringify(activeHexagon) && activeHexagon.length != 0) {
         sendCommandBlocks();
     }
     hexCache = activeHexagon;
@@ -405,6 +405,7 @@ const sleep = (milliseconds) => {
             <input style="width: 50%" bind:value={rotation}/> &deg
             <br/>
             <button on:click={() => moveable.request("rotatable",{rotate: initialRotation}, true)}>Reset</button>
+            {activeHexagon}
         </div>
     {/if}
 

--- a/src/Utils/Hexagons.svelte
+++ b/src/Utils/Hexagons.svelte
@@ -411,7 +411,6 @@ const sleep = (milliseconds) => {
             <input style="width: 50%" bind:value={rotation}/> &deg
             <br/>
             <button on:click={() => moveable.request("rotatable",{rotate: initialRotation}, true)}>Reset</button>
-            {activeHexagon}
         </div>
     {/if}
 

--- a/src/routes/Manual.svelte
+++ b/src/routes/Manual.svelte
@@ -30,7 +30,8 @@ $: connectionAttempt = (async () => {
 
 // MARK: Antenna Configuration
 // Add a feature to stop the RF field.
-
+$: fieldState = 1; //defualt on
+$: fieldStateString = fieldState === 1 ? "Off" : "On";
 $: rfPower = 4;
 $: activeRfPower = 0;
 $: configuring = false;
@@ -40,6 +41,29 @@ $: rf_command = `{ "SetRadioFreqPower": { "power_level": ${rfPower}} }`
 const reset_command = '{ "SystemReset": { } }';
 
 $: configureAttempt = {};
+
+function handleRfField(Com) {
+    let stateString;
+    if (fieldState) {
+        console.log("Turn RF field OFF");
+        fieldState = 0;
+        stateString = "Off";
+    } else {
+        console.log("Turn RF field ON");
+        fieldState = 1;
+        stateString = "On";
+    }
+    let field_power_command = `{ "RfFieldState": { "state": ${fieldState} } }`;
+    console.log(fieldState);
+    console.log(field_power_command);
+    (async () => {
+        return await Com.hitEndpoint(endpoint, nopRoute, field_power_command);
+    })().then(result => {
+        $message = "Field is "+stateString;
+    }).catch(error => {
+        $message = error;
+    });
+}
 
 function handleClickRfPower() {
     configureAttempt = (async () => {
@@ -159,6 +183,7 @@ function handleSetTiming(Hex) {
             {/await}
             </div>    
             <h2>Antenna Configuration</h2>
+            <button on:click={handleRfField(Com)}>Turn RF Field {fieldStateString}</button>
 
             <label for="rfPower">RF Power (W)</label> <input bind:value={rfPower} />
             <button on:click={handleClickRfPower} disabled={antennaButtonDisabled}> {antennaButtonMessage} </button>

--- a/src/routes/Manual.svelte
+++ b/src/routes/Manual.svelte
@@ -109,7 +109,7 @@ $: single_pulse_pause = 250;
 $: singlePulse = false;
 $: {
     if(singlePulse) {
-        $command = 0x05;
+        $command = 0x04;
     } else {
         $command = 0x02;
     }

--- a/src/routes/Manual.svelte
+++ b/src/routes/Manual.svelte
@@ -90,7 +90,11 @@ $: {
         $command = 0x02;
     }
    }
-
+/*Timing blocks are 3 bytes each. For each block the first byte has the 8 msb of the first value, second byte has the 4lsb of the first value and the 4msb of the second value, the third byte has the 8lsb of the second value
+    Ex: For single pulse | t_pulse(8 msb) | t_pulse(4lsb) and t_pause(4msb) | t_pause(8lsb) | 
+    If t_pulse = 1000ms (0x3E8) and t_pause = 250ms(0FA): |3E |80| FA|
+*/
+        
 $: $single_pulse_block = [(single_pulse_duration & 0x00000ff0) >> 4,(single_pulse_duration & 0x0000000f) << 4 | (single_pulse_pause & 0x00000f00)>>8,single_pulse_pause & 0x000000ff];
 //set freq to 1kHz (start with 200Hz)
 $: hfOn = hfPeriod * (hfDutyCycle/100);
@@ -121,8 +125,10 @@ function handleCollapse() {
 }
 
 function handleSetTiming(Hex) {
+    let temp = $cmd_op;
     $cmd_op = 0x00;
     Hex.sendCommandBlocks();
+    $cmd_op = temp;
 }
 </script>
 

--- a/src/routes/Manual.svelte
+++ b/src/routes/Manual.svelte
@@ -1,6 +1,6 @@
 <script>
 import { Router, Link, Route } from "svelte-routing";
-import { lf_block, hf_block, single_pulse_block, message, devices, activeDevice, command } from "../../stores/stores";
+import { lf_block, hf_block, single_pulse_block, message, devices, activeDevice, command, block0_31, cmd_op } from "../../stores/stores";
 import Communication from "../Utils/Communication.svelte";
 import Devices from "../Utils/Devices.svelte";
 import Hexagons from "../Utils/Hexagons.svelte";
@@ -119,6 +119,11 @@ function handleCollapse() {
         configContent.style.display = "block";
     }
 }
+
+function handleSetTiming(Hex) {
+    $cmd_op = 0x00;
+    Hex.sendCommandBlocks();
+}
 </script>
 
 <main>
@@ -174,6 +179,8 @@ function handleCollapse() {
             <Link to="infer"><button>Infer Timer Config</button></Link>
             <br/>
             <button on:click={Hex.AllOff()}>All Off</button>
+            <br/>
+            <button on:click={handleSetTiming(Hex)}>Set Timing</button>
             <Route path="/">
                 <h3>Manually Specify Timing</h3>
                 <div on:load="{setTimingBlock("hideLF")}"></div>

--- a/src/routes/PreparedSequences.svelte
+++ b/src/routes/PreparedSequences.svelte
@@ -1,7 +1,7 @@
 <script>
     import { Router, Link, Route } from 'svelte-routing';
     import Devices from '../Utils/Devices.svelte';
-    import {message, OP_Mode} from '../../stores/stores';
+    import {message} from '../../stores/stores';
     import Hexagons from '../Utils/Hexagons.svelte';
 </script>
 

--- a/stores/stores.js
+++ b/stores/stores.js
@@ -4,24 +4,24 @@ export const message = writable("starting...");
 
 export const command = writable(0x02); //Sets timing options (alloff, single pulse,...)
 export const cmd_op = writable(0x01);
+export const act_cnt8 = writable(5);
+
 export const activeDevice = writable(0);
 export const devices = writable([]);
-
-// export const stichables = writable([]);
 
 export const block0_31 = writable([0,0,0,0]);
 export const block32_63 = writable([0,0,0,0]);
 export const block64_95 = writable([0,0,0,0]);
 export const block96_127 = writable([0,0,0,0]);
 
-export const single_pulse_block = writable([0, 0, 0, 0]);
-export const hf_block = writable([0, 0, 0, 0]);
-export const lf_block = writable([0, 0, 0, 0]);
+export const single_pulse_block = writable([0, 0, 0]);
+export const hf_block = writable([0, 0, 0]);
+export const lf_block = writable([0, 0, 0]);
 
 export const act_command = derived([command, cmd_op, devices, activeDevice, block0_31, block32_63, block64_95, block96_127, single_pulse_block, hf_block, lf_block],
     ([$command, $cmd_op, $devices, $activeDevice, $block0_31, $block32_63, $block64_95, $block96_127, $single_pulse_block, $hf_block, $lf_block]) => `{ "ActuatorsCommand": {
     "fabric_name": "${$devices[$activeDevice]}",
-    "op_mode_block": {"act_cnt8":5, "cmd_op":${$cmd_op}, "command":${$command}},
+    "op_mode_block": {"act_cnt8":${$act_cnt8}, "cmd_op":${$cmd_op}, "command":${$command}},
     "actuator_mode_blocks": {
       "block0_31":{"b0": ${$block0_31[0]}, "b1": ${$block0_31[1]}, "b2": ${$block0_31[2]}, "b3": ${$block0_31[3]}},
       "block32_63":{"b0": ${$block32_63[0]}, "b1": ${$block32_63[1]}, "b2": ${$block32_63[2]}, "b3": ${$block32_63[3]}},

--- a/stores/stores.js
+++ b/stores/stores.js
@@ -3,6 +3,7 @@ import { derived, readable, writable } from 'svelte/store';
 export const message = writable("starting...");
 
 export const command = writable(0x02); //Sets timing options (alloff, single pulse,...)
+export const cmd_op = writable(0x01);
 export const activeDevice = writable(0);
 export const devices = writable([]);
 
@@ -17,10 +18,10 @@ export const single_pulse_block = writable([0, 0, 0, 0]);
 export const hf_block = writable([0, 0, 0, 0]);
 export const lf_block = writable([0, 0, 0, 0]);
 
-export const act_command = derived([command, devices, activeDevice, block0_31, block32_63, block64_95, block96_127, single_pulse_block, hf_block, lf_block],
-    ([command, $devices, $activeDevice, $block0_31, $block32_63, $block64_95, $block96_127, $single_pulse_block, $hf_block, $lf_block]) => `{ "ActuatorsCommand": {
+export const act_command = derived([command, cmd_op, devices, activeDevice, block0_31, block32_63, block64_95, block96_127, single_pulse_block, hf_block, lf_block],
+    ([$command, $cmd_op, $devices, $activeDevice, $block0_31, $block32_63, $block64_95, $block96_127, $single_pulse_block, $hf_block, $lf_block]) => `{ "ActuatorsCommand": {
     "fabric_name": "${$devices[$activeDevice]}",
-    "op_mode_block": {"act_cnt8":5, "cmd_op":0, "command":${command}},
+    "op_mode_block": {"act_cnt8":5, "cmd_op":${$cmd_op}, "command":${$command}},
     "actuator_mode_blocks": {
       "block0_31":{"b0": ${$block0_31[0]}, "b1": ${$block0_31[1]}, "b2": ${$block0_31[2]}, "b3": ${$block0_31[3]}},
       "block32_63":{"b0": ${$block32_63[0]}, "b1": ${$block32_63[1]}, "b2": ${$block32_63[2]}, "b3": ${$block32_63[3]}},

--- a/stores/stores.js
+++ b/stores/stores.js
@@ -2,7 +2,7 @@ import { derived, readable, writable } from 'svelte/store';
 
 export const message = writable("starting...");
 
-export const OP_Mode = writable(0x02);
+export const command = writable(0x02); //Sets timing options (alloff, single pulse,...)
 export const activeDevice = writable(0);
 export const devices = writable([]);
 
@@ -17,19 +17,19 @@ export const single_pulse_block = writable([0, 0, 0, 0]);
 export const hf_block = writable([0, 0, 0, 0]);
 export const lf_block = writable([0, 0, 0, 0]);
 
-export const act_command = derived([OP_Mode, devices, activeDevice, block0_31, block32_63, block64_95, block96_127, single_pulse_block, hf_block, lf_block],
-    ([$OP_Mode, $devices, $activeDevice, $block0_31, $block32_63, $block64_95, $block96_127, $single_pulse_block, $hf_block, $lf_block]) => `{ "ActuatorsCommand": {
+export const act_command = derived([command, devices, activeDevice, block0_31, block32_63, block64_95, block96_127, single_pulse_block, hf_block, lf_block],
+    ([command, $devices, $activeDevice, $block0_31, $block32_63, $block64_95, $block96_127, $single_pulse_block, $hf_block, $lf_block]) => `{ "ActuatorsCommand": {
     "fabric_name": "${$devices[$activeDevice]}",
-    "op_mode_block": {"act_cnt32":2, "act_mode":0, "op_mode":${$OP_Mode}},
+    "op_mode_block": {"act_cnt8":5, "cmd_op":0, "command":${command}},
     "actuator_mode_blocks": {
       "block0_31":{"b0": ${$block0_31[0]}, "b1": ${$block0_31[1]}, "b2": ${$block0_31[2]}, "b3": ${$block0_31[3]}},
       "block32_63":{"b0": ${$block32_63[0]}, "b1": ${$block32_63[1]}, "b2": ${$block32_63[2]}, "b3": ${$block32_63[3]}},
       "block64_95":{"b0": ${$block64_95[0]}, "b1": ${$block64_95[1]}, "b2": ${$block64_95[2]}, "b3": ${$block64_95[3]}},
       "block96_127":{"b0": ${$block96_127[0]}, "b1": ${$block96_127[1]}, "b2": ${$block96_127[2]}, "b3": ${$block96_127[3]}}},
     "timer_mode_blocks": {
-      "single_pulse_block":{"b0":${$single_pulse_block[0]}, "b1":${$single_pulse_block[1]}, "b2":${$single_pulse_block[2]}, "b3":${$single_pulse_block[3]}},
-      "hf_block":{"b0":${$hf_block[0]}, "b1":${$hf_block[1]}, "b2":${$hf_block[2]}, "b3":${$hf_block[3]}},
-      "lf_block":{"b0":${$lf_block[0]}, "b1":${$lf_block[1]}, "b2":${$lf_block[2]}, "b3":${$lf_block[3]}}
+      "single_pulse_block":{"b0":${$single_pulse_block[0]}, "b1":${$single_pulse_block[1]}, "b2":${$single_pulse_block[2]}},
+      "hf_block":{"b0":${$hf_block[0]}, "b1":${$hf_block[1]}, "b2":${$hf_block[2]}},
+      "lf_block":{"b0":${$lf_block[0]}, "b1":${$lf_block[1]}, "b2":${$lf_block[2]}}
     } } }`);
 
 


### PR DESCRIPTION
Names, values, and calculations for act_command fields were updated to
match the new firmware protocol.

Several fields were renamed to avoid confusion. Ex. OP_mode -> command
since OP_mode now refers to different bytes in the command.

A timing block field was removed to match new firmware, and math was changed
since each timing block now consists of 3 bytes.